### PR TITLE
chore(p0): gel du repo — AGENTS.md, .tool-versions, ADR

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-hugo extended 0.140.0
+hugo extended 0.161.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+hugo extended 0.140.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ travaillant sur la refonte du site `manufacture.dev`.
 
 | Composant      | Choix retenu                              |
 |----------------|-------------------------------------------|
-| SSG            | Hugo ≥ 0.140 extended                     |
+| SSG            | Hugo ≥ 0.161 extended                     |
 | CSS            | Custom Properties + BEM léger             |
 | JavaScript     | Vanilla JS uniquement                     |
 | Icônes         | SVG inline                                |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,11 +91,30 @@ origin/feat/p3-tokens   ──→ PR vers redesign
 Avant de soumettre une PR, vérifier :
 
 - [ ] `hugo build` passe sans erreur ni warning
-- [ ] Comparaison visuelle (avant/après) pour les changements UI
+- [ ] Vérification visuelle locale avec Agent-browser (voir ci-dessous)
 - [ ] Pas de régression Lighthouse (score ≥ 95 sur les 4 catégories)
 - [ ] 0 erreur console dans le navigateur
 - [ ] Accessibilité : titres hiérarchiques, alt sur images, contraste AA
 - [ ] Pas de nouvelle dépendance externe (npm, CDN)
+
+### Vérification visuelle locale (Agent-browser)
+
+Pour tout changement impactant l'UI, lancer le site en local et le vérifier via
+[Agent-browser](https://agent-browser.dev/skills) :
+
+```bash
+# 1. Démarrer le serveur Hugo local (comme indiqué dans le README)
+hugo server -D
+# Le site est disponible sur http://localhost:1313
+```
+
+Puis utiliser la skill Agent-browser pour vérifier les pages clés :
+- Homepage FR : `http://localhost:1313/`
+- Homepage EN : `http://localhost:1313/en/`
+- Une page intérieure (ex. : `http://localhost:1313/offer/`)
+
+Contrôles visuels à effectuer : mise en page cohérente, navigation fonctionnelle,
+images chargées, pas d'élément cassé ou déplacé par rapport à l'état précédent.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,131 @@
+# AGENTS.md — Conventions de la refonte manufacture.dev
+
+Ce fichier documente les conventions à suivre pour tous les agents et contributeurs
+travaillant sur la refonte du site `manufacture.dev`.
+
+---
+
+## Stack technique
+
+| Composant      | Choix retenu                              |
+|----------------|-------------------------------------------|
+| SSG            | Hugo ≥ 0.140 extended                     |
+| CSS            | Custom Properties + BEM léger             |
+| JavaScript     | Vanilla JS uniquement                     |
+| Icônes         | SVG inline                                |
+| Pipeline build | Hugo Pipes (dart-sass intégré)            |
+
+## Ce qu'on supprime
+
+- **Bootstrap** — remplacé par CSS Custom Properties + BEM léger
+- **jQuery** — remplacé par Vanilla JS
+- **Slick** (carousel) — remplacé par CSS scroll snap ou solution native
+- **iconfont themefisher** — remplacé par SVG inline
+- **Google Fonts CDN** — polices auto-hébergées ou system fonts
+
+## Cibles qualité
+
+- **Lighthouse ≥ 95** sur les 4 catégories : Performance, SEO, Accessibilité, Best Practices
+- **WCAG AA** — conformité accessibilité niveau AA
+- **0 erreur console** en production
+- **Zéro dépendance npm** — build 100% Hugo Pipes
+
+---
+
+## Convention de commits
+
+Format : `type(pN): message court`
+
+Exemples :
+```
+feat(p3): tokens couleur et typographie
+chore(p2): vendor thème manufacture depuis terracotta
+fix(p4): contraste bouton CTA insuffisant
+perf(p6): optimisation images WebP
+docs(p0): ADR analytics
+```
+
+### Types valides
+
+| Type       | Usage                                           |
+|------------|-------------------------------------------------|
+| `feat`     | Nouvelle fonctionnalité ou composant            |
+| `fix`      | Correction de bug ou régression                 |
+| `chore`    | Tâche de maintenance, setup, configuration      |
+| `refactor` | Restructuration sans changement de comportement |
+| `perf`     | Amélioration de performance                     |
+| `docs`     | Documentation, ADR, commentaires                |
+| `test`     | Ajout ou modification de tests                  |
+
+### Identifiant de phase `pN`
+
+- `p0` — Préparation (gel, branches, ADR)
+- `p1` — Audit et inventaire
+- `p2` — Vendor du thème
+- `p3` — Design tokens et typographie
+- `p4` — Composants UI
+- `p5` — Contenu et formulaires
+- `p6` — Performance et assets
+- `p7` — Analytics, cookies, RGPD
+- `p8` — Tests, QA, bascule production
+
+---
+
+## Workflow branches
+
+```
+upstream/main   ←── PR finale de bascule (Phase 8 uniquement)
+upstream/redesign ←── toutes les PR de refonte (p0 → p7)
+origin/chore/p0-prep ──→ PR vers redesign
+origin/feat/p3-tokens   ──→ PR vers redesign
+...
+```
+
+**Règle absolue : toutes les PR ciblent `redesign`, jamais `main` directement**
+(sauf la PR finale de mise en production en Phase 8).
+
+---
+
+## Checklist PR
+
+Avant de soumettre une PR, vérifier :
+
+- [ ] `hugo build` passe sans erreur ni warning
+- [ ] Comparaison visuelle (avant/après) pour les changements UI
+- [ ] Pas de régression Lighthouse (score ≥ 95 sur les 4 catégories)
+- [ ] 0 erreur console dans le navigateur
+- [ ] Accessibilité : titres hiérarchiques, alt sur images, contraste AA
+- [ ] Pas de nouvelle dépendance externe (npm, CDN)
+
+---
+
+## Structure du repo
+
+```
+/
+├── AGENTS.md              # Ce fichier
+├── .tool-versions         # Versions des outils (Hugo)
+├── config/                # Configuration Hugo
+├── content/               # Contenu Markdown
+├── themes/manufacture/    # Thème custom (Phase 2+)
+├── assets/                # CSS, JS, images sources
+├── static/                # Fichiers statiques copiés tels quels
+├── layouts/               # Overrides de layouts (si besoin)
+└── docs/
+    └── decisions/         # ADR (Architecture Decision Records)
+```
+
+---
+
+## ADR (Architecture Decision Records)
+
+Les décisions d'architecture sont documentées dans `docs/decisions/`.
+Format de nommage : `NNNN-titre-kebab-case.md`
+
+| Fichier                           | Sujet                        | Statut              |
+|-----------------------------------|------------------------------|---------------------|
+| `0001-vendor-theme.md`            | Vendor du thème terracotta   | Accepté             |
+| `0002-css-stack.md`               | Stack CSS                    | Accepté             |
+| `0003-analytics.md`               | Solution analytics           | En attente          |
+| `0004-form-backend.md`            | Backend formulaire contact   | En attente          |
+| `0005-captcha.md`                 | Solution captcha             | En attente          |

--- a/docs/decisions/0001-vendor-theme.md
+++ b/docs/decisions/0001-vendor-theme.md
@@ -8,10 +8,16 @@
 ## Contexte
 
 Le site actuel utilise le thème Hugo `terracotta` référencé comme submodule git via SSH
-(`git@github.com:…`). Cette configuration pose deux problèmes bloquants :
+(`git@github.com:manufacture-dev/terracotta.git`).
 
-1. **CI bloquée** : le clone SSH échoue dans les environnements CI/CD sans clé SSH
-   configurée (GitHub Actions, Netlify, etc.), rendant les builds automatiques fragiles.
+Cette configuration pose plusieurs problèmes :
+
+1. **Accessibilité depuis les sandboxes des agents** : lors des phases de travail automatisé
+   (agents IA, environnements de développement éphémères), le repo du thème
+   `manufacture-dev/terracotta` peut ne pas être accessible depuis la sandbox de l'agent.
+   Vendorer le thème directement dans le repo principal garantit que tous les outils et
+   agents peuvent travailler localement sans dépendance externe sur le repo du submodule.
+
 2. **Thème à réécrire** : le thème terracotta est conçu pour du e-commerce ; la refonte
    vise un site de services B2B, ce qui nécessite une réécriture quasi-complète du thème.
    Maintenir un lien vers l'upstream n'a donc pas de valeur.
@@ -25,7 +31,8 @@ Le site actuel utilise le thème Hugo `terracotta` référencé comme submodule 
 ## Conséquences
 
 **Positives :**
-- Build CI reproductible sans clé SSH ni submodule.
+- Travail local reproductible dans tous les environnements (agents, CI, développeurs)
+  sans dépendance sur l'accessibilité du repo du submodule.
 - Liberté totale de modifier le thème sans contrainte de compatibilité upstream.
 - Un seul dépôt à gérer, historique unifié.
 

--- a/docs/decisions/0001-vendor-theme.md
+++ b/docs/decisions/0001-vendor-theme.md
@@ -1,0 +1,39 @@
+# ADR 0001 — Vendor du thème terracotta dans le repo
+
+- **Date** : 2026-05-06
+- **Statut** : Accepté
+
+---
+
+## Contexte
+
+Le site actuel utilise le thème Hugo `terracotta` référencé comme submodule git via SSH
+(`git@github.com:…`). Cette configuration pose deux problèmes bloquants :
+
+1. **CI bloquée** : le clone SSH échoue dans les environnements CI/CD sans clé SSH
+   configurée (GitHub Actions, Netlify, etc.), rendant les builds automatiques fragiles.
+2. **Thème à réécrire** : le thème terracotta est conçu pour du e-commerce ; la refonte
+   vise un site de services B2B, ce qui nécessite une réécriture quasi-complète du thème.
+   Maintenir un lien vers l'upstream n'a donc pas de valeur.
+
+## Décision
+
+- Copier le contenu de `themes/terracotta` dans `themes/manufacture` directement dans le repo.
+- Supprimer le fichier `.gitmodules` et la référence au submodule.
+- Le thème `manufacture` devient un thème first-party, versionné dans ce repo.
+
+## Conséquences
+
+**Positives :**
+- Build CI reproductible sans clé SSH ni submodule.
+- Liberté totale de modifier le thème sans contrainte de compatibilité upstream.
+- Un seul dépôt à gérer, historique unifié.
+
+**Négatives :**
+- Aucune mise à jour automatique depuis le thème terracotta (non souhaitée de toute façon).
+- Légère augmentation de la taille du repo (assets du thème copiés).
+
+## Référence
+
+- Phase d'implémentation : **Phase 2** (vendor du thème)
+- Branche cible : `redesign`

--- a/docs/decisions/0002-css-stack.md
+++ b/docs/decisions/0002-css-stack.md
@@ -1,0 +1,50 @@
+# ADR 0002 — Stack CSS : Custom Properties + BEM léger
+
+- **Date** : 2026-05-06
+- **Statut** : Accepté
+
+---
+
+## Contexte
+
+Le site actuel embarque Bootstrap 4 pour la mise en page et les composants UI. Bootstrap
+introduit ~200 Ko de CSS non utilisé, une dépendance npm, et des conventions de classe
+utilitaire qui alourdissent le HTML. La refonte vise un Lighthouse ≥ 95 sur toutes les
+catégories, ce qui requiert un budget CSS très serré.
+
+Alternatives évaluées :
+
+| Option              | Dépendances | Taille approx. | Adapté au projet |
+|---------------------|-------------|----------------|------------------|
+| Bootstrap 5         | npm         | ~160 Ko        | Non              |
+| Tailwind CSS        | npm + purge | ~10–30 Ko      | Trop verbeux     |
+| Custom Properties + BEM | Aucune  | < 20 Ko        | **Oui**          |
+
+Le site comporte environ 12 composants distincts (hero, nav, cards, testimonials, CTA,
+footer, formulaire…). Un framework utility-first serait surdimensionné.
+
+## Décision
+
+- Utiliser les **CSS Custom Properties** pour les design tokens (couleurs, typographie,
+  espacements, breakpoints).
+- Suivre une convention **BEM légère** (Block__Element--Modifier) pour nommer les
+  composants, sans générateur automatique.
+- Utiliser **Hugo Pipes avec dart-sass intégré** pour compiler les fichiers SCSS.
+- **Aucune dépendance npm** : pas de `package.json`, pas de `node_modules`.
+
+## Conséquences
+
+**Positives :**
+- Build 100% Hugo Pipes, zéro outil Node requis.
+- CSS produit minimal, performant, facilement auditable.
+- Design tokens centralisés dans un fichier `_tokens.scss`, modifiables en un endroit.
+- Maintenabilité maximale : un développeur junior peut lire et modifier le CSS.
+
+**Négatives :**
+- Pas de classes utilitaires prêtes à l'emploi : chaque composant est à écrire.
+- Discipline BEM à maintenir manuellement (pas de linter de convention de nommage prévu).
+
+## Référence
+
+- Phase d'implémentation : **Phase 3** (design tokens) et **Phase 4** (composants UI)
+- Branche cible : `redesign`

--- a/docs/decisions/0003-analytics.md
+++ b/docs/decisions/0003-analytics.md
@@ -1,0 +1,54 @@
+# ADR 0003 — Solution analytics
+
+- **Date** : 2026-05-06
+- **Statut** : En attente de décision
+
+---
+
+## Contexte
+
+Le site actuel utilise Google Tag Manager (GTM) pour charger Google Analytics 4 (GA4).
+GTM est bloqué par de nombreux bloqueurs de publicité (uBlock Origin, Brave, etc.),
+ce qui fausse les métriques. GTM charge du JavaScript tiers au démarrage, impactant
+négativement le score Lighthouse Performance.
+
+De plus, l'utilisation de GA4 via GTM implique le dépôt de cookies analytiques, soumis
+au consentement RGPD, ce qui nécessite une bannière de consentement.
+
+## Options
+
+### Option A — Solution cookieless (Plausible ou Umami)
+
+- **Principe** : analytics sans cookie, données agrégées et anonymisées.
+- **RGPD** : aucun consentement requis, pas de bannière.
+- **Performance** : script léger (~1 Ko), non bloqué par les ad-blockers.
+- **Coût** : Plausible ~9 €/mois (SaaS) ou auto-hébergement Umami (gratuit, infra requise).
+- **Inconvénient** : moins de données comportementales fines que GA4.
+
+### Option B — Conserver GTM + Klaro pour le consentement
+
+- **Principe** : garder GTM/GA4 existant, ajouter une bannière de consentement avec Klaro.
+- **RGPD** : conforme avec consentement explicite.
+- **Performance** : GTM retardé après consentement (impact Lighthouse réduit).
+- **Inconvénient** : complexité accrue, dépendance à un service Google, UX dégradée par la bannière.
+
+## Impact selon la décision
+
+| Décision | Action en Phase 7                                    |
+|----------|------------------------------------------------------|
+| Option A | Supprimer GTM du layout, intégrer script Plausible/Umami |
+| Option B | Conserver GTM, intégrer Klaro + bannière consentement RGPD |
+
+## Décision
+
+> ⏳ **À décider avant le démarrage de la Phase 7.**
+
+Critères de décision recommandés :
+- Volume et granularité des données analytics nécessaires au business.
+- Appétence pour l'auto-hébergement (Umami) ou un SaaS tiers (Plausible).
+- Priorité donnée à la conformité RGPD sans friction utilisateur.
+
+## Référence
+
+- Phase d'implémentation : **Phase 7** (analytics, cookies, RGPD)
+- Branche cible : `redesign`

--- a/docs/decisions/0004-form-backend.md
+++ b/docs/decisions/0004-form-backend.md
@@ -1,0 +1,64 @@
+# ADR 0004 — Backend du formulaire de contact
+
+- **Date** : 2026-05-06
+- **Statut** : En attente de décision
+
+---
+
+## Contexte
+
+Le site actuel utilise `staticforms.xyz` comme backend pour le formulaire de contact.
+Ce service présente des incertitudes quant à sa pérennité, sa conformité RGPD, et sa
+fiabilité à long terme. La refonte est l'occasion de choisir un service plus robuste.
+
+Le formulaire de contact est la seule fonctionnalité dynamique du site (Hugo est
+100% statique). Le backend doit :
+
+- Recevoir les soumissions HTTP POST
+- Envoyer un e-mail de notification
+- Être compatible RGPD (données hébergées en UE ou sous accord DPA)
+- Ne pas nécessiter de backend custom
+
+## Options
+
+### Option A — Formspree
+
+- Service spécialisé formulaires statiques, très répandu.
+- Offre gratuite : 50 soumissions/mois.
+- RGPD : DPA disponible sur les plans payants.
+- Intégration : `<form action="https://formspree.io/f/XXXX">`.
+
+### Option B — Web3Forms
+
+- Service plus récent, offre gratuite généreuse (250 soumissions/mois).
+- Données traitées hors UE par défaut (à vérifier).
+- Intégration similaire à Formspree.
+
+### Option C — Conserver staticforms.xyz
+
+- Aucune migration nécessaire.
+- Incertitude sur la pérennité et la conformité RGPD.
+- Non recommandé pour une refonte long terme.
+
+## Critères de décision
+
+| Critère                  | Formspree | Web3Forms | staticforms.xyz |
+|--------------------------|-----------|-----------|-----------------|
+| RGPD / DPA disponible    | Oui (payant) | À vérifier | Inconnu       |
+| Offre gratuite           | 50/mois   | 250/mois  | Oui             |
+| Pérennité                | Bonne     | Correcte  | Inconnue        |
+| Facilité d'intégration   | ✓         | ✓         | ✓               |
+
+## Impact
+
+La décision impacte uniquement le `action` du formulaire HTML et éventuellement
+un champ caché (`_next`, `access_key`, etc.) selon le service retenu.
+
+## Décision
+
+> ⏳ **À décider avant le démarrage de la Phase 5.**
+
+## Référence
+
+- Phase d'implémentation : **Phase 5** (contenu et formulaires)
+- Branche cible : `redesign`

--- a/docs/decisions/0005-captcha.md
+++ b/docs/decisions/0005-captcha.md
@@ -1,0 +1,60 @@
+# ADR 0005 — Solution captcha
+
+- **Date** : 2026-05-06
+- **Statut** : En attente de décision
+
+---
+
+## Contexte
+
+Le formulaire de contact utilise actuellement reCAPTCHA v2 (Google). Cette solution
+présente plusieurs inconvénients :
+
+- **RGPD** : reCAPTCHA dépose des cookies tiers Google, nécessitant un consentement
+  explicite ; des amendes RGPD ont été prononcées en Europe à ce sujet.
+- **Performance** : charge ~170 Ko de JavaScript Google au démarrage.
+- **Friction utilisateur** : les cases à cocher et défis visuels dégradent l'UX.
+- **Dépendance Google** : couplage fort avec l'écosystème Google.
+
+## Options
+
+### Option A — Cloudflare Turnstile (recommandé)
+
+- **Principe** : challenge invisible ou non-interactif, RGPD-natif (sans cookie traceur).
+- **RGPD** : conforme par design, pas de consentement requis selon Cloudflare.
+- **Performance** : script léger, chargé à la demande.
+- **Coût** : gratuit (1 million de défis/mois sur le plan Free).
+- **Intégration** : widget JS + validation côté backend (ou délégué au service de formulaire).
+
+### Option B — Conserver reCAPTCHA v2
+
+- Aucune migration nécessaire.
+- Problèmes RGPD et performance non résolus.
+- Non recommandé dans le cadre de la refonte.
+
+### Option C — Honeypot seul (sans captcha)
+
+- **Principe** : champ caché dans le formulaire, rempli uniquement par les bots.
+- **RGPD** : aucune donnée tiers collectée.
+- **Performance** : zéro JavaScript supplémentaire.
+- **Limite** : efficacité insuffisante contre les bots sophistiqués.
+- Peut être combiné avec l'Option A (double protection).
+
+## Recommandation
+
+**Option A (Cloudflare Turnstile)**, idéalement combinée avec un honeypot (Option C).
+Cette combinaison maximise la protection tout en restant RGPD-conforme et performante.
+
+## Impact
+
+La décision s'applique conjointement à la décision analytics (ADR 0003) et au choix
+du backend formulaire (ADR 0004). Les trois décisions doivent être cohérentes.
+
+## Décision
+
+> ⏳ **À décider avant le démarrage de la Phase 7**, en cohérence avec ADR 0003.
+
+## Référence
+
+- Phase d'implémentation : **Phase 7** (analytics, cookies, RGPD)
+- Branche cible : `redesign`


### PR DESCRIPTION
## Phase 0 — Préparation de la refonte

Pose les fondations du workflow de refonte sans toucher à `main`.

**Fichiers créés :**
- `AGENTS.md` — conventions stack, commits, workflow branches, checklist PR
- `.tool-versions` — Hugo extended 0.140.0
- `docs/decisions/0001-vendor-theme.md` — vendor thème terracotta (Accepté)
- `docs/decisions/0002-css-stack.md` — CSS Custom Properties + BEM (Accepté)
- `docs/decisions/0003-analytics.md` — analytics cookieless vs GTM (En attente)
- `docs/decisions/0004-form-backend.md` — backend formulaire contact (En attente)
- `docs/decisions/0005-captcha.md` — captcha Turnstile vs reCAPTCHA (En attente)

**Actions git réalisées :**
- Tag `legacy-2026-05` posé sur `main` (snapshot de rollback avant refonte)
- Branche `redesign` créée sur upstream (cible de toutes les PR p0→p7)

Toutes les PR de refonte ciblent `redesign`, jamais `main` directement.