### PR TITLE
chore(p0): enrichir .gitignore — secrets, IDE, OS, agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,28 @@
+# IDE
 .idea/
-.DS_Store
+.vscode/
+*.swp
+*.swo
 
+# OS
+.DS_Store
+Thumbs.db
+
+# Hugo
 .hugo_build.lock
 /public/
 /resources/
+
+# Secrets & credentials (ne jamais committer)
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+
+# Polecat / agents runtime (overlay de travail, ne pas versionner)
+CLAUDE.md
+.beads
+.claude
+.runtime


### PR DESCRIPTION
Ajoute des patterns manquants au `.gitignore` par hygiène de sécurité.

**Ajouts :**
- Secrets : `.env`, `.env.*`, `*.pem`, `*.key`, `*.p12`, `*.pfx` — évite de committer accidentellement des credentials
- IDE : `.vscode/`, `*.swp`, `*.swo` (complète `.idea/` déjà présent)
- OS : `Thumbs.db` (complète `.DS_Store` déjà présent)
- Agents runtime : `CLAUDE.md`, `.beads`, `.claude`, `.runtime` — fichiers overlay polecat déjà exclus en pratique mais pas formalisés