### PR TITLE
chore(p1): bump Hugo 0.90.1 → 0.161.1 — fix i18n flat map + summarylength

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@ title = "Manufacture | Technical coaching for efficient organisations"
 theme = "terracotta"
 DefaultContentLanguage = "fr"
 # post excert
-summarylength = "20"
+summarylength = 20
 # disable language
 disableLanguages = [] # disable language from here
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,53 +1,18 @@
-- id: "home"
-  translation: "Home"
-
-- id: "offer"
-  translation: "Offer"
-
-- id: "about"
-  translation: "About"
-
-- id: "faq"
-  translation: "FAQ"
-
-- id: "join-us"
-  translation: "Join us"
-
-- id: "contact"
-  translation: "Contact"
-
-- id: "legal-notice"
-  translation: "Legal Notice"
-
-- id: "privacy-policy"
-  translation: "Privacy Policy"
-
-- id: "lastname"
-  translation: "Last name"
-
-- id: "firstname"
-  translation: "First name"
-
-- id: "business"
-  translation: "Business"
-
-- id: "phone-number"
-  translation: "Phone number"
-
-- id: "linkedin"
-  translation: "LinkedIn profile link"
-
-- id: "email"
-  translation: "Email address"
-
-- id: "message"
-  translation: "Your message"
-
-- id: "send"
-  translation: "Send Now"
-  
-- id: "subscribe"
-  translation: "Subscribe"
-  
-- id: "read_more"
-  translation: "Read More"
+home: "Home"
+offer: "Offer"
+about: "About"
+faq: "FAQ"
+join-us: "Join us"
+contact: "Contact"
+legal-notice: "Legal Notice"
+privacy-policy: "Privacy Policy"
+lastname: "Last name"
+firstname: "First name"
+business: "Business"
+phone-number: "Phone number"
+linkedin: "LinkedIn profile link"
+email: "Email address"
+message: "Your message"
+send: "Send Now"
+subscribe: "Subscribe"
+read_more: "Read More"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -1,53 +1,18 @@
-- id: "home"
-  translation: "Accueil"
-
-- id: "offer"
-  translation: "Offre"
-
-- id: "about"
-  translation: "À propos"
-
-- id: "faq"
-  translation: "FAQ"
-
-- id: "join-us"
-  translation: "Nous rejoindre"
-
-- id: "contact"
-  translation: "Contact"
-
-- id: "legal-notice"
-  translation: "Mentions légales"
-
-- id: "privacy-policy"
-  translation: "Politique de Confidentialité"
-  
-- id: "lastname"
-  translation: "Nom"
-
-- id: "firstname"
-  translation: "Prénom"
-
-- id: "business"
-  translation: "Entreprise"
-
-- id: "phone-number"
-  translation: "Numéro de téléphone"
-
-- id: "linkedin"
-  translation: "Lien profil LinkedIn"
-
-- id: "email"
-  translation: "Adresse e-mail"
-
-- id: "message"
-  translation: "Votre message"
-
-- id: "send"
-  translation: "Envoyer"
-  
-- id: "subscribe"
-  translation: "Souscrire"
-  
-- id: "read_more"
-  translation: "En Savoir Plus"
+home: "Accueil"
+offer: "Offre"
+about: "À propos"
+faq: "FAQ"
+join-us: "Nous rejoindre"
+contact: "Contact"
+legal-notice: "Mentions légales"
+privacy-policy: "Politique de Confidentialité"
+lastname: "Nom"
+firstname: "Prénom"
+business: "Entreprise"
+phone-number: "Numéro de téléphone"
+linkedin: "Lien profil LinkedIn"
+email: "Adresse e-mail"
+message: "Votre message"
+send: "Envoyer"
+subscribe: "Souscrire"
+read_more: "En Savoir Plus"


### PR DESCRIPTION
Corrige les 2 breaking changes bloquants pour Hugo 0.161.1.

**Fichiers modifiés :**
- `i18n/fr.yaml` + `i18n/en.yaml` : format legacy v1 (`- id/translation`) → flat map (`clé: valeur`), requis depuis Hugo 0.123
- `config.toml` : `summarylength = "20"` (string) → `summarylength = 20` (int)

**Build local Hugo 0.161.1 :** ✅ OK — 12 pages FR + 11 pages EN en 28ms, zéro erreur.

Warnings non bloquants restants :
- `languageCode`/`languageName` dépréciés → `locale`/`label` (Phase 3)
- Layouts manquants : thème submodule non initialisé en sandbox (normal)